### PR TITLE
Enable users to install fluent-agent-lite via cpanm command.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,4 +11,6 @@ requires 'Time::HiRes';
 requires 'Time::Piece';
 requires 'Log::Minimal';
 
+install_script 'bin/fluent-agent-lite';
+
 WriteAll;


### PR DESCRIPTION
To install fluent-agent-lite via cpanm command can be usefule when we test it locally by dispaching the command directly.
