### PR TITLE
remove $PID_FILE if process stopped.

### DIFF
--- a/package/fluent-agent-lite.init
+++ b/package/fluent-agent-lite.init
@@ -86,7 +86,7 @@ stop() {
 
     if [ $RETVAL = 0 ]; then
         echo "ok."
-        echo -n > $PID_FILE
+        rm -f $PID_FILE
     else
         echo "failed. (timeout after 10sec)"
     fi


### PR DESCRIPTION
プロセスが停止しても、PID_FILEが0バイトのまま残ってしまっており、一見すると起動しているように見えるので削除するようにしました。
