### PR TITLE
Read 0 lines, not 10 lines at restarting (starting)

### DIFF
--- a/bin/fluent-agent-lite
+++ b/bin/fluent-agent-lite
@@ -177,7 +177,7 @@ sub build_tail_command {
     if ($sleep_interval) {
         push @command, '-s', $sleep_interval;
     }
-    push @command, '-F', $input_file;
+    push @command, '-n', '0', '-F', $input_file;
     infof 'tail command line: %s', \@command;
     return @command;
 }


### PR DESCRIPTION
This is the simplest patch for the issue #10
