### PR TITLE
status returns 3 if service stopped

### DIFF
--- a/package/fluent-agent-lite.init
+++ b/package/fluent-agent-lite.init
@@ -134,6 +134,7 @@ status() {
     if [ $RETVAL = 0 ]; then
         if [ "x"$working = "x0" ]; then
             echo "not running, ok"
+            # ref: http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
             RETVAL=3
         else
             echo "ok."


### PR DESCRIPTION
停止しているときに`service fluent-agent-lite status`が0を返すと、puppetやserverspecがサービスのrunning/stoppedを判別出来ないため、3を返すようにします。
