### PR TITLE
Add reconnect_wait_max, and reconnect_wait_incr_rate options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Tag name of drain\_log (messages count per drain/send to server), which is emitt
 
 Connection keepalive time in seconds. 0 means infinity (Default: 1800, minimum: 120)
 
+### RECONNECT_WAIT_MAX
+
+The maximum wait time for TCP socket reconnection in seconds. (Default: 3600, minimum: 0.5)
+
+### RECONNECT_WAIT_INCR_RATE
+
+The rate to increment the reconnect time. `next_wait_time = current_wait_time * rate` (Default: 1.5, minimum: 1.0)
+
 ### LOG_PATH
 
 Log file path for 'fluent-agent-lite' (Default: /tmp/fluent-agent.log).

--- a/bin/fluent-agent-lite
+++ b/bin/fluent-agent-lite
@@ -34,7 +34,7 @@ my $checker_reconnect = sub {
 
 use Getopt::Std qw//;
 my %commandline_options;
-Getopt::Std::getopts('f:p:s:b:n:t:i:l:P:S:d:k:jvFh', \%commandline_options);
+Getopt::Std::getopts('f:p:s:b:n:t:i:l:P:S:d:k:w:r:jvFh', \%commandline_options);
 
 sub HELP_MESSAGE {
     print <<EOF;
@@ -43,23 +43,25 @@ Usage: fluent-agent-lite [options] TAG TARGET_FILE PRIMARY_SERVER[:PORT] [SECOND
 
        port default: 24224
 Options:
-     -f FIELDNAME       fieldname of fluentd log message attribute (DEFAULT: message)
-     -p LIST_PATH       primary servers list (server[:port] per line, random selected one server)
-     -s LIST_PATH       secondary servers list (server[:port] per line, random selected one server)
-     -b BUF_SIZE        log tailing buffer size (DEFAULT: 1MB)
-     -n NICE            tail process nice (DEFAULT: 0)
-     -t TAIL_PATH       tail path (DEFAULT: /usr/bin/tail)
-     -i SECONDS         tail -F sleep interval (GNU tail ONLY, DEFAULT: tail default)
-     -l LOG_PATH        log file path (DEFAULT: /tmp/fluent-agent.log)
-     -P TAG:DATA        send a ping message per minute with specified TAG and DATA (DEFAULT: not to send)
-                          (see also: fluent-plugin-ping-message)
-     -S SECONDS         ping message interval seconds (DEFAULT: 60)
-     -d DRAIN_LOG_TAG   emits drain log to fluentd: messages per drain/send (DEFAULT: not to emits)
-     -k KEEPALIVE_TIME  connection keepalive time in seconds. 0 means infinity (DEFAULT: 1800, minimum: 120)
-     -j                 use JSON for message structure in transfering (highly experimental)
-     -v                 output logs of level debug and info (DEFAULT: warn/crit only)
-     -F                 force start even if input file is not found
-     -h                 print this message
+     -f FIELDNAME                fieldname of fluentd log message attribute (DEFAULT: message)
+     -p LIST_PATH                primary servers list (server[:port] per line, random selected one server)
+     -s LIST_PATH                secondary servers list (server[:port] per line, random selected one server)
+     -b BUF_SIZE                 log tailing buffer size (DEFAULT: 1MB)
+     -n NICE                     tail process nice (DEFAULT: 0)
+     -t TAIL_PATH                tail path (DEFAULT: /usr/bin/tail)
+     -i SECONDS                  tail -F sleep interval (GNU tail ONLY, DEFAULT: tail default)
+     -l LOG_PATH                 log file path (DEFAULT: /tmp/fluent-agent.log)
+     -P TAG:DATA                 send a ping message per minute with specified TAG and DATA (DEFAULT: not to send)
+                                   (see also: fluent-plugin-ping-message)
+     -S SECONDS                  ping message interval seconds (DEFAULT: 60)
+     -d DRAIN_LOG_TAG            emits drain log to fluentd: messages per drain/send (DEFAULT: not to emits)
+     -k KEEPALIVE_TIME           connection keepalive time in seconds. 0 means infinity (DEFAULT: 1800, minimum: 120)
+     -w RECONNECT_WAIT_MAX       the maximum wait time for TCP socket reconnection in seconds (DEFAULT: 3600, minimum: 0.5)
+     -r RECONNECT_WAIT_INCR_RATE the rate to increment the reconnect time (DEFAULT: 1.5, minimum: 1.0)
+     -j                          use JSON for message structure in transfering (highly experimental)
+     -v                          output logs of level debug and info (DEFAULT: warn/crit only)
+     -F                          force start even if input file is not found
+     -h                          print this message
 EOF
     exit 0;
 }
@@ -156,6 +158,14 @@ my $keepalive_time = undef;
 if (defined $commandline_options{k} and $commandline_options{k} >= 0) {
     $keepalive_time = $commandline_options{k};
 }
+my $reconnect_wait_max = undef;
+if (defined $commandline_options{w} and $commandline_options{w} >= 0) {
+    $reconnect_wait_max = $commandline_options{w};
+}
+my $reconnect_wait_incr_rate = undef;
+if (defined $commandline_options{r} and $commandline_options{r} >= 0) {
+    $reconnect_wait_incr_rate = $commandline_options{r};
+}
 
 my $output_format = undef; # default: MessagePack
 if ($commandline_options{j}) {
@@ -234,6 +244,8 @@ sub main {
             ping_message => $ping_message,
             drain_log_tag => $drain_log_tag,
             keepalive_time => $keepalive_time,
+            reconnect_wait_max => $reconnect_wait_max,
+            reconnect_wait_incr_rate => $reconnect_wait_incr_rate,
             output_format => $output_format,
         },
     );

--- a/package/fluent-agent-lite.conf
+++ b/package/fluent-agent-lite.conf
@@ -47,6 +47,12 @@ PRIMARY_SERVER="primary.fluentd.local:24224"
 # connection keepalive time in seconds. 0 means infinity (DEFAULT: 1800)
 # KEEPALIVE_TIME=1800
 
+# The maximum wait time for TCP socket reconnection in seconds (Default: 3600, minimum: 0.5)
+# RECONNECT_WAIT_MAX=3600
+
+# The rate to increment the reconnect time (Default: 1.5)
+# RECONNECT_WAIT_INCR_RATE=1.5
+
 # LOG_PATH=/tmp/fluent-agent.log
 # LOG_VERBOSE=false
 

--- a/package/fluent-agent-lite.init
+++ b/package/fluent-agent-lite.init
@@ -218,6 +218,12 @@ function prepare_build {
     if [ "x"$KEEPALIVE_TIME != "x" ]; then
         OPTIONS_PART=$OPTIONS_PART" -k "$KEEPALIVE_TIME
     fi
+    if [ "x"$RECONNECT_WAIT_MAX != "x" ]; then
+        OPTIONS_PART=$OPTIONS_PART" -w "$RECONNECT_WAIT_MAX
+    fi
+    if [ "x"$RECONNECT_WAIT_INCR_RATE != "x" ]; then
+        OPTIONS_PART=$OPTIONS_PART" -r "$RECONNECT_WAIT_INCR_RATE
+    fi
     if [ "x"$LOG_PATH != "x" ]; then
         OPTIONS_PART=$OPTIONS_PART" -l "$LOG_PATH
     fi


### PR DESCRIPTION
Added options to configure RECONNECT_WAIT_MAX, and RECONNECT_WAIT_INCR_RATE.

I added following options to bin/fluent-agent-lite, and still wondering for `-r`. Any opinions?

```
-w RECONNECT_WAIT_MAX
-r RECONNECT_WAIT_INCR_RATE
```
