### PR TITLE
replace cpanm URL

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -31,7 +31,7 @@ cp -rp bin lib Makefile.PL $INSTALLDIR
 
 cd $INSTALLDIR
 
-curl -s -L http://xrl.us/cpanm > $INSTALLDIR/bin/cpanm
+curl -s -L http://cpanmin.us > $INSTALLDIR/bin/cpanm
 chmod +x $INSTALLDIR/bin/cpanm
 $PERL_PATH $INSTALLDIR/bin/cpanm -n -lextlib inc::Module::Install
 $PERL_PATH $INSTALLDIR/bin/cpanm -n -lextlib --reinstall --installdeps .


### PR DESCRIPTION
I have faced 500 Internal Server Error when I access to http://xrl.us/cpanm, so I can't build rpm package.
Currently we can get the standalone executable script from http://cpanmin.us.
via. https://github.com/miyagawa/cpanminus/commit/fa971c02a9d3f857c5c0576aa43365f66d495f18#diff-04c6e90faac2675aa89e2176d2eec7d8
